### PR TITLE
Add desktop navigation menu

### DIFF
--- a/components/desktop-menu.tsx
+++ b/components/desktop-menu.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Link from "next/link"
+
+import { NavItem } from "@/types/nav"
+import { cn } from "@/lib/utils"
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+} from "@/components/ui/navigation-menu"
+
+interface DesktopMenuProps extends React.HTMLAttributes<HTMLDivElement> {
+  items: NavItem[]
+}
+
+export function DesktopMenu({ items, className, ...props }: DesktopMenuProps) {
+  if (!items?.length) return null
+  return (
+    <NavigationMenu className={cn("hidden md:flex", className)} {...props}>
+      <NavigationMenuList>
+        {items.map((item) => (
+          <NavigationMenuItem key={item.href}>
+            <Link href={item.href} legacyBehavior passHref>
+              <NavigationMenuLink className="px-3 py-2">{item.title}</NavigationMenuLink>
+            </Link>
+          </NavigationMenuItem>
+        ))}
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -8,6 +8,7 @@ import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
 import { MobileMenu } from "@/components/MobileMenu"
 import { BurgerMenu } from "@/components/burger-menu"
+import { DesktopMenu } from "@/components/desktop-menu"
 
 interface MainNavProps {
   items?: NavItem[]
@@ -21,12 +22,15 @@ export function MainNav({ items }: MainNavProps) {
   }
   return (
     <>
-      <div className="flex gap-6 px-2 md:gap-10">
-        <Link href="/" className="items-center space-x-2 md:flex">
-          <span className="font-bold sm:inline-block">{siteConfig.name}</span>
-        </Link>
+      <div className="flex w-full items-center justify-between">
+        <div className="flex gap-6 px-2 md:gap-10">
+          <Link href="/" className="items-center space-x-2 md:flex">
+            <span className="font-bold sm:inline-block">{siteConfig.name}</span>
+          </Link>
+        </div>
+        {items && <DesktopMenu items={items} />}
+        <BurgerMenu onClick={toggleDropdown} className="px-2 md:hidden" />
       </div>
-      <BurgerMenu onClick={toggleDropdown} className="px-2 md:hidden" />
       {showMobileMenu && items && (
         <MobileMenu className="animate-in fade-in duration-500" items={items} />
       )}

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import * as React from "react"
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
+
+import { cva } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+)
+
+const NavigationMenu = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative z-10 flex max-w-max items-center justify-center",
+      className
+    )}
+    {...props}
+  />
+))
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
+
+const NavigationMenuList = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    ref={ref}
+    className={cn(
+      "flex list-none items-center space-x-4",
+      className
+    )}
+    {...props}
+  />
+))
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item
+
+const NavigationMenuLink = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Link>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Link>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Link
+    ref={ref}
+    className={cn(
+      "block select-none text-sm font-medium leading-none no-underline outline-none transition-colors hover:text-foreground/80 focus:text-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+NavigationMenuLink.displayName = NavigationMenuPrimitive.Link.displayName
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+}


### PR DESCRIPTION
## Summary
- implement NavigationMenu component based on shadcn library
- create DesktopMenu component using NavigationMenu
- add DesktopMenu to MainNav so items show on desktop

## Testing
- `npm run lint` *(fails: `next` not found)*