### PR TITLE
Add desktop nav menu

### DIFF
--- a/components/desktop-menu.tsx
+++ b/components/desktop-menu.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import Link from "next/link"
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuLink,
+} from "@radix-ui/react-navigation-menu"
+
+import { NavItem } from "@/types/nav"
+import { cn } from "@/lib/utils"
+
+interface DesktopMenuProps {
+  items?: NavItem[]
+  className?: string
+}
+
+const DesktopMenu = React.forwardRef<HTMLDivElement, DesktopMenuProps>(
+  ({ items, className }, ref) => {
+    if (!items?.length) return null
+    return (
+      <NavigationMenu ref={ref} className={cn("hidden md:block", className)}>
+        <NavigationMenuList className="flex gap-6">
+          {items.map((item) => (
+            <NavigationMenuItem key={item.href}>
+              <Link href={item.href} legacyBehavior passHref>
+                <NavigationMenuLink className="px-2 py-1 text-sm font-medium hover:text-foreground/80">
+                  {item.title}
+                </NavigationMenuLink>
+              </Link>
+            </NavigationMenuItem>
+          ))}
+        </NavigationMenuList>
+      </NavigationMenu>
+    )
+  }
+)
+DesktopMenu.displayName = "DesktopMenu"
+
+export { DesktopMenu }

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -8,6 +8,7 @@ import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
 import { MobileMenu } from "@/components/MobileMenu"
 import { BurgerMenu } from "@/components/burger-menu"
+import { DesktopMenu } from "@/components/desktop-menu"
 
 interface MainNavProps {
   items?: NavItem[]
@@ -26,6 +27,7 @@ export function MainNav({ items }: MainNavProps) {
           <span className="font-bold sm:inline-block">{siteConfig.name}</span>
         </Link>
       </div>
+      <DesktopMenu items={items} className="ml-4" />
       <BurgerMenu onClick={toggleDropdown} className="px-2 md:hidden" />
       {showMobileMenu && items && (
         <MobileMenu className="animate-in fade-in duration-500" items={items} />

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slider": "^1.1.2",
+    "@radix-ui/react-navigation-menu": "^1.0.6",
     "@vercel/analytics": "^1.0.2",
     "class-variance-authority": "^0.4.0",
     "clsx": "^1.2.1",


### PR DESCRIPTION
## Summary
- add DesktopMenu component using shadcn navigation menu
- show DesktopMenu in main navigation
- declare @radix-ui/react-navigation-menu dependency

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683f8cf5dd98832db2a5ab5b8d02e2f9