### PR TITLE
[codex] Add OpenFreeMap story markers

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import { notFound } from "next/navigation"
 import { fetchPosts } from "@/lib/api"
 import Post from "@/components/Post"
 
@@ -48,7 +49,7 @@ export default async function PostPage({ params }: PostProps) {
   const post = await getPostFromParams(params)
 
   if (!post) {
-    throw new Error("Failed to fetch posts")
+    notFound()
   }
 
   return <Post post={post} />

--- a/app/osm-experiments/page.tsx
+++ b/app/osm-experiments/page.tsx
@@ -1,0 +1,53 @@
+import { fetchPosts } from "@/lib/api"
+import { OSMExperimentMap } from "@/components/osm-experiment-map"
+import { SiteFooter } from "@/components/site-footer"
+import { SiteHeader } from "@/components/site-header"
+
+export default async function OSMExperimentsPage() {
+  const posts = await fetchPosts()
+
+  return (
+    <>
+      <SiteHeader />
+      <main className="pb-16 pt-24 sm:pt-28">
+        <section className="container space-y-8 px-4 sm:px-6">
+          <div className="space-y-5 pt-2">
+            <h1 className="max-w-4xl text-4xl font-black tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              OSM Noise Experiments
+            </h1>
+            <p className="max-w-3xl text-lg leading-8 text-muted-foreground">
+              These options keep the standard OpenStreetMap raster tiles and
+              only soften the rendered image. They can reduce color noise, but
+              they cannot truly remove POIs, icons, or labels the way a custom
+              vector style can.
+            </p>
+          </div>
+
+          <div className="grid gap-10">
+            <OSMExperimentMap
+              posts={posts}
+              title="Default OSM"
+              variant="default"
+            />
+            <OSMExperimentMap
+              posts={posts}
+              title="Muted OSM"
+              variant="muted"
+            />
+            <OSMExperimentMap
+              posts={posts}
+              title="Paper OSM"
+              variant="paper"
+            />
+            <OSMExperimentMap
+              posts={posts}
+              title="Monochrome OSM"
+              variant="mono"
+            />
+          </div>
+        </section>
+      </main>
+      <SiteFooter className="pb-8" />
+    </>
+  )
+}

--- a/components/home-map.tsx
+++ b/components/home-map.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useMemo, useRef } from "react"
 import type PostType from "@/interfaces/post"
 
-import { getRuntimeBasemapConfig } from "@/lib/map-basemaps"
-
 export type MapViewport = {
   lat: number
   lng: number
@@ -34,7 +32,7 @@ export function HomeMap({
   viewport,
 }: Props) {
   const mapRef = useRef<HTMLDivElement | null>(null)
-  const mapInstanceRef = useRef<import("leaflet").Map | null>(null)
+  const mapInstanceRef = useRef<import("maplibre-gl").Map | null>(null)
   const postsRef = useRef(posts)
   const viewportRef = useRef(viewport)
   const visibleCallbackRef = useRef(onVisibleSlugsChange)
@@ -69,27 +67,15 @@ export function HomeMap({
 
   useEffect(() => {
     let isMounted = true
-    let map: import("leaflet").Map | null = null
+    let map: import("maplibre-gl").Map | null = null
 
     async function setupMap() {
       if (!mapRef.current) {
         return
       }
 
-      const leafletModule = await import("leaflet")
-      const L = leafletModule.default ?? leafletModule
-      ;(
-        globalThis as typeof globalThis & {
-          L?: typeof L
-          window?: Window & typeof globalThis & { L?: typeof L }
-        }
-      ).L = L
-
-      if (typeof window !== "undefined") {
-        ;(window as Window & typeof globalThis & { L?: typeof L }).L = L
-      }
-
-      await import("leaflet.markercluster/dist/leaflet.markercluster-src.js")
+      const maplibreModule = await import("maplibre-gl")
+      const maplibregl = maplibreModule.default ?? maplibreModule
 
       if (!isMounted || !mapRef.current) {
         return
@@ -97,52 +83,42 @@ export function HomeMap({
 
       const currentPosts = postsRef.current
       const currentViewport = viewportRef.current
-      const currentBasemap = getRuntimeBasemapConfig(window.location.hostname)
+      const initialCenter = currentViewport
+        ? ([currentViewport.lng, currentViewport.lat] as [number, number])
+        : ([174.76, -36.85] as [number, number])
 
-      map = L.map(mapRef.current, {
-        attributionControl: false,
+      map = new maplibregl.Map({
+        attributionControl: { compact: true },
+        center: initialCenter,
+        container: mapRef.current,
         keyboard: false,
-        scrollWheelZoom: false,
+        maxZoom: 17,
+        minZoom: 8,
+        scrollZoom: false,
+        style: "https://tiles.openfreemap.org/styles/liberty",
+        zoom: currentViewport?.z ?? 10,
       })
       mapInstanceRef.current = map
+      const activeMap = map
 
-      L.tileLayer(currentBasemap.tileUrl, {
-        attribution: currentBasemap.attribution,
-        maxZoom: 19,
-      }).addTo(map)
-
-      const bounds = L.latLngBounds(
-        currentPosts.map(
-          (post) => [post.location.lat, post.location.lng] as [number, number]
-        )
+      activeMap.addControl(
+        new maplibregl.NavigationControl({ showCompass: false }),
+        "top-right"
       )
 
-      const globalLeaflet = (
-        globalThis as typeof globalThis & {
-          L?: typeof L & {
-            markerClusterGroup?: (options?: object) => {
-              addLayer: (layer: import("leaflet").Layer) => void
-            } & import("leaflet").Layer
-          }
-        }
-      ).L
-
-      const clusterFactory = globalLeaflet?.markerClusterGroup
-      const clusterGroup = clusterFactory?.({
-        showCoverageOnHover: false,
-        maxClusterRadius: 40,
-      })
-
       currentPosts.forEach((post) => {
-        const marker = L.circleMarker([post.location.lat, post.location.lng], {
-          radius: 7,
-          color: "#ffffff",
-          weight: 3,
-          fillColor: "#0f172a",
-          fillOpacity: 1,
-        })
+        const markerElement = document.createElement("a")
+        markerElement.className = "tn-map-marker"
+        markerElement.href = `/${post.slug}`
+        markerElement.ariaLabel = post.name
+        markerElement.dataset.testid = "home-map-marker"
 
-        marker.bindPopup(
+        const popup = new maplibregl.Popup({
+          closeButton: true,
+          closeOnClick: true,
+          maxWidth: "220px",
+          offset: 18,
+        }).setHTML(
           `
             <div style="width: 190px; font-family: sans-serif;">
               <a href="/${post.slug}" style="display: block; color: inherit; text-decoration: none;">
@@ -157,28 +133,21 @@ export function HomeMap({
                 <a href="/${post.slug}" style="color: #0f172a; text-decoration: underline;">Open story</a>
               </div>
             </div>
-          `,
-          { maxWidth: 220, minWidth: 190 }
+          `
         )
 
-        if (clusterGroup) {
-          clusterGroup.addLayer(marker)
-        } else if (map) {
-          marker.addTo(map)
-        }
+        new maplibregl.Marker({ element: markerElement })
+          .setLngLat([post.location.lng, post.location.lat])
+          .setPopup(popup)
+          .addTo(activeMap)
       })
 
-      if (clusterGroup) {
-        map.addLayer(clusterGroup)
-      }
-
-      if (currentViewport) {
-        map.setView(
-          [currentViewport.lat, currentViewport.lng],
-          currentViewport.z
-        )
-      } else {
-        map.fitBounds(bounds.pad(0.35))
+      if (!currentViewport && currentPosts.length > 0) {
+        const bounds = new maplibregl.LngLatBounds()
+        currentPosts.forEach((post) => {
+          bounds.extend([post.location.lng, post.location.lat])
+        })
+        activeMap.fitBounds(bounds, { padding: 72 })
       }
 
       const updateVisiblePosts = () => {
@@ -189,7 +158,7 @@ export function HomeMap({
         const currentBounds = map.getBounds()
         const visible = currentPosts
           .filter((post) =>
-            currentBounds.contains([post.location.lat, post.location.lng])
+            currentBounds.contains([post.location.lng, post.location.lat])
           )
           .map((post) => post.slug)
 
@@ -205,14 +174,16 @@ export function HomeMap({
         viewportCallbackRef.current({
           lat: Number(center.lat.toFixed(6)),
           lng: Number(center.lng.toFixed(6)),
-          z: map.getZoom(),
+          z: Number(map.getZoom().toFixed(2)),
         })
       }
 
       updateVisiblePosts()
       updateViewport()
-      map.on("moveend zoomend", updateVisiblePosts)
-      map.on("moveend zoomend", updateViewport)
+      map.on("moveend", updateVisiblePosts)
+      map.on("zoomend", updateVisiblePosts)
+      map.on("moveend", updateViewport)
+      map.on("zoomend", updateViewport)
     }
 
     setupMap()
@@ -244,13 +215,14 @@ export function HomeMap({
       return
     }
 
-    map.setView([viewport.lat, viewport.lng], viewport.z, { animate: false })
+    map.jumpTo({ center: [viewport.lng, viewport.lat], zoom: viewport.z })
   }, [viewport])
 
   return (
     <div className="overflow-hidden border border-border/70 shadow-sm">
       <div
         ref={mapRef}
+        data-testid="home-map"
         className="h-[360px] w-full sm:h-[420px] lg:h-[540px]"
         aria-label="Map of story locations"
       />

--- a/components/osm-experiment-map.tsx
+++ b/components/osm-experiment-map.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from "react"
+import type PostType from "@/interfaces/post"
+
+type MapVariant = "default" | "muted" | "paper" | "mono"
+
+type Props = {
+  posts: PostType[]
+  title: string
+  variant: MapVariant
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+export function OSMExperimentMap({ posts, title, variant }: Props) {
+  const mapRef = useRef<HTMLDivElement | null>(null)
+
+  const postsKey = useMemo(
+    () =>
+      posts
+        .map(
+          (post) =>
+            `${post.slug}:${post.location.lat.toFixed(6)}:${post.location.lng.toFixed(6)}`
+        )
+        .join("|"),
+    [posts]
+  )
+
+  useEffect(() => {
+    let isMounted = true
+    let map: import("leaflet").Map | null = null
+
+    async function setupMap() {
+      if (!mapRef.current) {
+        return
+      }
+
+      const leafletModule = await import("leaflet")
+      const L = leafletModule.default ?? leafletModule
+      ;(
+        globalThis as typeof globalThis & {
+          L?: typeof L
+          window?: Window & typeof globalThis & { L?: typeof L }
+        }
+      ).L = L
+
+      if (typeof window !== "undefined") {
+        ;(window as Window & typeof globalThis & { L?: typeof L }).L = L
+      }
+
+      await import("leaflet.markercluster/dist/leaflet.markercluster-src.js")
+
+      if (!isMounted || !mapRef.current) {
+        return
+      }
+
+      map = L.map(mapRef.current, {
+        attributionControl: false,
+        keyboard: false,
+        scrollWheelZoom: false,
+      })
+
+      L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        maxZoom: 19,
+      }).addTo(map)
+
+      const bounds = L.latLngBounds(
+        posts.map(
+          (post) => [post.location.lat, post.location.lng] as [number, number]
+        )
+      )
+
+      const globalLeaflet = (
+        globalThis as typeof globalThis & {
+          L?: typeof L & {
+            markerClusterGroup?: (options?: object) => {
+              addLayer: (layer: import("leaflet").Layer) => void
+            } & import("leaflet").Layer
+          }
+        }
+      ).L
+
+      const clusterFactory = globalLeaflet?.markerClusterGroup
+      const clusterGroup = clusterFactory?.({
+        showCoverageOnHover: false,
+        maxClusterRadius: 40,
+      })
+
+      posts.forEach((post) => {
+        const marker = L.circleMarker([post.location.lat, post.location.lng], {
+          radius: 7,
+          color: "#ffffff",
+          weight: 3,
+          fillColor: variant === "default" ? "#0f172a" : "#111827",
+          fillOpacity: 1,
+        })
+
+        marker.bindPopup(
+          `
+            <div style="width: 190px; font-family: sans-serif;">
+              <a href="/${post.slug}" style="display: block; color: inherit; text-decoration: none;">
+                <img
+                  src="${post.ba_imageUrl}"
+                  alt="${escapeHtml(post.name)}"
+                  style="display: block; width: 100%; height: 110px; object-fit: cover; margin-bottom: 10px;"
+                />
+                <strong style="display: block; font-size: 14px; line-height: 1.35;">${escapeHtml(post.name)}</strong>
+              </a>
+            </div>
+          `,
+          { maxWidth: 220, minWidth: 190 }
+        )
+
+        if (clusterGroup) {
+          clusterGroup.addLayer(marker)
+        } else if (map) {
+          marker.addTo(map)
+        }
+      })
+
+      if (clusterGroup) {
+        map.addLayer(clusterGroup)
+      }
+
+      map.fitBounds(bounds.pad(0.35))
+    }
+
+    setupMap()
+
+    return () => {
+      isMounted = false
+      map?.remove()
+    }
+  }, [posts, postsKey, variant])
+
+  return (
+    <article className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+        <p className="text-sm text-muted-foreground">
+          Raster OSM only. This is just visual softening, not true layer
+          removal.
+        </p>
+      </div>
+      <div className="overflow-hidden border border-border/70 shadow-sm">
+        <div
+          ref={mapRef}
+          className={`tn-osm-variant tn-osm-variant--${variant} h-[320px] w-full sm:h-[380px]`}
+        />
+      </div>
+    </article>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "lucide-react": "1.8.0",
+    "maplibre-gl": "^5.23.0",
     "next": "16.2.4",
     "next-themes": "0.4.6",
     "react": "19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       lucide-react:
         specifier: 1.8.0
         version: 1.8.0(react@19.2.5)
+      maplibre-gl:
+        specifier: ^5.23.0
+        version: 5.23.0
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -477,6 +480,42 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.1.0':
+    resolution: {integrity: sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/geojson-vt@6.1.0':
+    resolution: {integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.8.1':
+    resolution: {integrity: sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.8':
+    resolution: {integrity: sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==}
+
+  '@maplibre/vt-pbf@4.3.0':
+    resolution: {integrity: sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -989,6 +1028,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
+
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1423,6 +1465,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
@@ -1708,6 +1753,9 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1926,6 +1974,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -1938,6 +1989,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2061,6 +2115,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  maplibre-gl@5.23.0:
+    resolution: {integrity: sha512-aou8YBNFS8uVtDWFWt0W/6oorfl18wt+oIA8fnXk1kivjkbtXi9gGrQvflTpwrR3hG13aWdIdbYWeN0NFMV7ag==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2088,6 +2146,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2202,6 +2263,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2244,6 +2309,9 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2256,6 +2324,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2265,6 +2336,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   react-compare-image@3.5.16:
     resolution: {integrity: sha512-+95FaJKJ87DD+KNb4frSx08Z02xJ+LjScpJ8MTgRIizhi5iwAney2oTkDDYkaBjcHD+C+J/x3iK1iIg+5/dwtQ==}
@@ -2385,6 +2459,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve@2.0.0-next.6:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
@@ -2396,6 +2473,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -2516,6 +2596,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2551,6 +2634,9 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2993,6 +3079,52 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.1.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/geojson-vt@6.1.0':
+    dependencies:
+      kdbush: 4.0.2
+
+  '@maplibre/maplibre-gl-style-spec@24.8.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.8':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.1
+      supercluster: 8.0.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -3414,6 +3546,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
@@ -3837,6 +3973,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  earcut@3.0.2: {}
 
   electron-to-chromium@1.5.340: {}
 
@@ -4279,6 +4417,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4486,6 +4626,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -4498,6 +4640,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4597,6 +4741,28 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@5.23.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.1.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.0
+      '@maplibre/maplibre-gl-style-spec': 24.8.1
+      '@maplibre/mlt': 1.1.8
+      '@maplibre/vt-pbf': 4.3.0
+      '@types/geojson': 7946.0.16
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -4624,6 +4790,8 @@ snapshots:
       ufo: 1.6.3
 
   ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -4747,6 +4915,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4789,6 +4961,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
@@ -4799,11 +4973,15 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protocol-buffers-schema@3.6.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   react-compare-image@3.5.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -4917,6 +5095,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
   resolve@2.0.0-next.6:
     dependencies:
       es-errors: 1.3.0
@@ -4931,6 +5113,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -5114,6 +5298,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5145,6 +5333,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyqueue@3.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,7 @@
 @import "leaflet/dist/leaflet.css";
 @import "leaflet.markercluster/dist/MarkerCluster.css";
 @import "leaflet.markercluster/dist/MarkerCluster.Default.css";
+@import "maplibre-gl/dist/maplibre-gl.css";
 @import "tailwindcss";
 @config "../tailwind.config.js";
 
@@ -134,4 +135,41 @@
 
 .leaflet-tile {
   filter: saturate(0.7) brightness(1.04) contrast(0.9);
+}
+
+.tn-osm-variant--default .leaflet-tile {
+  filter: none;
+}
+
+.tn-osm-variant--muted .leaflet-tile {
+  filter: saturate(0.58) brightness(1.06) contrast(0.9);
+}
+
+.tn-osm-variant--paper .leaflet-tile {
+  filter: grayscale(0.35) saturate(0.5) brightness(1.12) contrast(0.84);
+}
+
+.tn-osm-variant--mono .leaflet-tile {
+  filter: grayscale(0.82) brightness(1.08) contrast(0.88);
+}
+
+.tn-map-marker {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border: 3px solid white;
+  border-radius: 9999px;
+  background: hsl(var(--foreground));
+  box-shadow: 0 2px 10px rgb(15 23 42 / 0.28);
+  cursor: pointer;
+}
+
+.tn-map-marker:focus-visible {
+  outline: 3px solid hsl(var(--ring));
+  outline-offset: 3px;
+}
+
+.maplibregl-popup-content {
+  border-radius: 0.5rem;
+  box-shadow: 0 12px 32px rgb(15 23 42 / 0.18);
 }

--- a/tests/e2e/home-map.spec.ts
+++ b/tests/e2e/home-map.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+test("homepage renders the OpenFreeMap map with story markers", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByTestId("home-map")).toBeVisible();
+  await expect(page.locator(".maplibregl-canvas")).toBeVisible();
+  await expect(page.getByTestId("home-map-marker").first()).toBeVisible();
+
+  const markerCount = await page.getByTestId("home-map-marker").count();
+  expect(markerCount).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

- Switches the homepage story map to MapLibre using OpenFreeMap's Liberty style.
- Adds clickable story markers with popups and preserves the existing visible-story/viewport URL behavior.
- Adds the OSM raster experiment route and marker/map styling used in the preview.
- Converts missing story slugs to `notFound()` instead of throwing an app error.
- Adds Playwright coverage for the homepage map canvas and rendered markers.

## Preview

https://thennow-mxo5y7ux0-kpoxo6ops-projects.vercel.app

## Validation

- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test:e2e`